### PR TITLE
Fix display of named disposable vms

### DIFF
--- a/qubes_menu/custom_widgets.py
+++ b/qubes_menu/custom_widgets.py
@@ -187,7 +187,8 @@ class VMRow(HoverListBox):
         style_context: Gtk.StyleContext = self.get_style_context()
         if self.vm_entry.is_dispvm_template:
             style_context.add_class('dvm_template_entry')
-        elif self.vm_entry.vm_klass == 'DispVM':
+        elif self.vm_entry.parent_vm:
+            # has a parent VM means that it should have arrow etc.
             style_context.add_class('dispvm_entry')
         else:
             style_context.remove_class('dispvm_entry')

--- a/qubes_menu/vm_manager.py
+++ b/qubes_menu/vm_manager.py
@@ -38,10 +38,13 @@ class VMEntry:
         self.vm_name = str(vm)
         self.vm_klass = vm.klass
 
-        self.sort_name = f'{str(self.vm.template.name)}:{self.vm_name}'\
-            if hasattr(self.vm, 'template') and self.vm_klass == 'DispVM' \
-            else self.vm_name
-        self.parent_vm = self.vm.template if self.vm.klass == 'DispVM' else None
+        if self.vm.klass == 'DispVM' and self.vm.auto_cleanup:
+            self.parent_vm = self.vm.template
+            self.sort_name = f'{str(self.parent_vm.name)}:{self.vm_name}'
+        else:
+            self.parent_vm = None
+            self.sort_name = self.vm_name
+
         self._servicevm = bool(self.vm.features.get("servicevm", False))
         self._is_dispvm_template = getattr(
             self.vm, 'template_for_dispvms', False)


### PR DESCRIPTION
For display purposes, they should be treated like normal qubes: only have their own applications and not have the "hey I'm child of this template" lines.

fixes QubesOS/qubes-issues#7841