### PR TITLE
Fix move to/from events being ignored for .desktop files

### DIFF
--- a/qubes_menu/desktop_file_manager.py
+++ b/qubes_menu/desktop_file_manager.py
@@ -162,6 +162,14 @@ class DesktopFileManager:
             except FileNotFoundError:
                 self.parent.remove_file(event.pathname)
 
+        def process_IN_MOVED_FROM(self, event):
+            """On move from, act like delete happened."""
+            self.process_IN_DELETE(event)
+
+        def process_IN_MOVED_TO(self, event):
+            """On move to, act like create happened."""
+            self.process_IN_CREATE(event)
+
     def __init__(self, qapp):
         self.qapp = qapp
         self.watch_manager = None
@@ -215,7 +223,7 @@ class DesktopFileManager:
     def load_file(self, path: Union[str, Path]):
         """
         Load a file. If file was already known, its ApplicationInfo is
-        refreshed, otherwise a new ApplicationInfo object will be creates and
+        refreshed, otherwise a new ApplicationInfo object will be created
         and all callbacks registered will be executed."""
         if isinstance(path, str):
             path = Path(path)
@@ -276,7 +284,9 @@ class DesktopFileManager:
         self.watch_manager = pyinotify.WatchManager()
 
         # pylint: disable=no-member
-        mask = pyinotify.IN_CREATE | pyinotify.IN_DELETE | pyinotify.IN_MODIFY
+        mask = pyinotify.IN_CREATE | pyinotify.IN_DELETE | \
+               pyinotify.IN_MODIFY | pyinotify.IN_MOVED_FROM | \
+               pyinotify.IN_MOVED_TO
 
         loop = asyncio.get_event_loop()
 

--- a/qubes_menu/utils.py
+++ b/qubes_menu/utils.py
@@ -88,8 +88,14 @@ def highlight_words(labels: List[Gtk.Label], search_words: List[str]):
     """Highlight provided search_words in the provided labels."""
     if not labels:
         return
+    # try to find Application, if impossible, just give up on highlighting
+    # because it means we are trying to highlight in the middle of
+    # deleting some rows
 
-    hl_tag = labels[0].get_toplevel().get_application().highlight_tag
+    window = labels[0].get_ancestor(Gtk.Window)
+    if not window:
+        return
+    hl_tag = window.get_application().highlight_tag
 
     for label in labels:
         text = label.get_text()


### PR DESCRIPTION
Also a minor fix for a rare edge case in search: if the search row was being deleted, it could potentially generate a bunch of harmless exceptions while trying to highlight search terms.

fixes QubesOS/qubes-issues#8010