### PR TITLE
Set KillMode on menu to process

### DIFF
--- a/service_files/qubes-app-menu.service
+++ b/service_files/qubes-app-menu.service
@@ -9,3 +9,4 @@ Restart=on-failure
 RestartSec=1
 BusName=org.qubesos.appmenu
 Type=dbus
+KillMode=process


### PR DESCRIPTION
We don't actually want to kill spawned applications if menu restarts for any reason.