### PR TITLE
Better .desktop file and keep menu on top

### DIFF
--- a/desktop_files/open-qubes-app-menu.desktop
+++ b/desktop_files/open-qubes-app-menu.desktop
@@ -6,4 +6,4 @@ Terminal=false
 Name=Open Qubes Application Menu
 GenericName=Open Qubes Application Menu
 StartupNotify=false
-Hidden=True
+OnlyShowIn=X-Invalid;

--- a/qubes_menu/appmenu.py
+++ b/qubes_menu/appmenu.py
@@ -200,6 +200,7 @@ class AppMenu(Gtk.Application):
             if self.main_notebook:
                 self.main_notebook.set_current_page(self.initial_page)
             if self.main_window:
+                self.main_window.set_keep_above(True)
                 if self.main_window.is_visible() and not self.keep_visible:
                     self.main_window.hide()
                 else:


### PR DESCRIPTION
- Keep menu always on top
- Replace Hidden=true with OnlyShowIn=X-Invalid in the .desktop file to enable adding it to KDE panel