### PR TITLE
Add menu settings for initial menu page and sorting running qubes to top

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,11 +1,5 @@
 include:
   - project: 'QubesOS/qubes-continuous-integration'
-    file: '/r4.1/gitlab-base.yml'
-  - project: 'QubesOS/qubes-continuous-integration'
-    file: '/r4.1/gitlab-dom0.yml'
-  - project: 'QubesOS/qubes-continuous-integration'
-    file: '/r4.1/gitlab-vm.yml'
-  - project: 'QubesOS/qubes-continuous-integration'
     file: '/r4.2/gitlab-base.yml'
   - project: 'QubesOS/qubes-continuous-integration'
     file: '/r4.2/gitlab-host.yml'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@ checks:pylint:
     - pip3 install --quiet -r ci/requirements.txt
     - git clone https://github.com/QubesOS/qubes-core-admin-client ~/core-admin-client
   script:
-    - PYTHONPATH=~/core-admin-client:. python3 -m pylint --rcfile=.pylintrc qubes_menu
+    - PYTHONPATH=~/core-admin-client:. python3 -m pylint --rcfile=.pylintrc qubes_menu qubes_menu_settings
     - mypy
 
 checks:tests:
@@ -32,8 +32,9 @@ checks:tests:
       python3-coverage xorg-x11-server-Xvfb python3-inotify sequoia-sqv
     - pip3 install --quiet -r ci/requirements.txt
     - git clone https://github.com/QubesOS/qubes-core-admin-client ~/core-admin-client
+    - git clone https://github.com/QubesOS/qubes-desktop-linux-manager ~/desktop-linux-manager
   script:
-    - PYTHONPATH=~/core-admin-client:~/core-qrexec xvfb-run ./run-tests.sh
+    - PYTHONPATH=~/core-admin-client:~/desktop-linux-manager:. xvfb-run ./run-tests.sh
   after_script:
     - "PATH=$PATH:$HOME/.local/bin"
     - ci/codecov-wrapper

--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,14 @@ install-icons:
 	cp icons/qappmenu-qube.svg $(DESTDIR)/usr/share/icons/hicolor/scalable/apps/qappmenu-qube.svg
 	cp icons/qappmenu-search.svg $(DESTDIR)/usr/share/icons/hicolor/scalable/apps/qappmenu-search.svg
 	cp icons/qappmenu-settings.svg $(DESTDIR)/usr/share/icons/hicolor/scalable/apps/qappmenu-settings.svg
+	cp icons/appmenu-settings-program-icon.svg $(DESTDIR)/usr/share/icons/hicolor/scalable/apps/appmenu-settings-program-icon.svg
 
 install-autostart:
 	mkdir -p $(DESTDIR)/etc/xdg/autostart
 	cp autostart/qubes-app-menu.desktop $(DESTDIR)/etc/xdg/autostart
 	mkdir -p $(DESTDIR)/usr/share/applications
 	cp desktop_files/open-qubes-app-menu.desktop $(DESTDIR)/usr/share/applications/
+	cp desktop_files/qubes-appmenu-settings.desktop $(DESTDIR)/usr/share/applications/
 	mkdir -p $(DESTDIR)/lib/systemd/user/
 	cp service_files/qubes-app-menu.service $(DESTDIR)/lib/systemd/user/
 	mkdir -p $(DESTDIR)/usr/share/dbus-1/services/

--- a/debian/control
+++ b/debian/control
@@ -9,6 +9,11 @@ Build-Depends:
  python3-gbulb,
  python3-setuptools,
  python3-systemd,
+ python3-qubesadmin,
+ qubes-desktop-linux-manager,
+ python3-gi,
+ gobject-introspection,
+ gir1.2-gtk-3.0
 Standards-Version: 3.9.5
 Homepage: https://www.qubes-os.org/
 X-Python3-Version: >= 3.5

--- a/debian/rules
+++ b/debian/rules
@@ -6,7 +6,7 @@ DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/default.mk
 
 %:
-	dh $@ --with python3 --buildsystem=pybuild
+	dh $@ --with python3 --buildsystem=pybuild --test-pytest
 
 override_dh_auto_build: export http_proxy=127.0.0.1:9
 override_dh_auto_build: export https_proxy=127.0.0.1:9

--- a/desktop_files/qubes-appmenu-settings.desktop
+++ b/desktop_files/qubes-appmenu-settings.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Exec=qubes-appmenu-settings
+Icon=appmenu-settings-program-icon
+Terminal=false
+Name=Qubes Menu Settings
+GenericName=Qubes Menu Settings
+StartupNotify=false
+Categories=Settings;X-XFCE-SettingsDialog

--- a/icons/appmenu-settings-program-icon.svg
+++ b/icons/appmenu-settings-program-icon.svg
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="8.0551767mm"
+   height="9.8889723mm"
+   viewBox="0 0 8.0551767 9.8889723"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="qubes sjetcg.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="4.265404"
+     inkscape:cx="310.75602"
+     inkscape:cy="384.606"
+     inkscape:window-width="2482"
+     inkscape:window-height="1411"
+     inkscape:window-x="2391"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-148.77436,-89.636609)">
+    <rect
+       style="fill:#f9f9f9;fill-opacity:1;stroke:#b3b3b3;stroke-width:0.948;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       id="rect131"
+       width="7.1071682"
+       height="8.9409781"
+       x="149.24837"
+       y="90.110603"
+       ry="0.77813977" />
+    <g
+       id="g143"
+       transform="matrix(0.91487717,0,0,0.91487717,2.9377918,7.8809633)">
+      <path
+         id="path141"
+         style="fill:#63a0ff;fill-opacity:1;stroke-width:0.924227;stroke-linecap:round;stroke-linejoin:round"
+         inkscape:transform-center-x="1.6828228"
+         inkscape:transform-center-y="2.09e-05"
+         d="m 162.10302,93.6927 c -0.0343,0.0634 -0.0665,0.128997 -0.0913,0.193579 l -0.71852,0.1175 c -0.0637,0.01041 -0.11475,0.07202 -0.1175,0.137788 l -0.0228,1.104839 c -0.003,0.0722 0.046,0.124995 0.10905,0.137788 l 0.7143,0.08876 c 0.0646,0.165304 0.14525,0.319131 0.25191,0.461548 l -0.28403,0.691475 c -0.023,0.06756 -0.003,0.137486 0.0549,0.170756 l 0.92225,0.531709 c 0.0576,0.03327 0.13023,0.01842 0.17245,-0.03804 l 0.45732,-0.591728 c 0.0957,0.01147 0.19147,0.01382 0.28657,0.01015 V 95.6733 c -0.17219,0.0043 -0.34511,-0.03614 -0.50213,-0.126798 -0.45858,-0.264762 -0.61622,-0.863223 -0.36772,-1.35421 z" />
+      <path
+         id="path142"
+         style="fill:#3874d8;fill-opacity:1;stroke-width:0.924227;stroke-linecap:round;stroke-linejoin:round"
+         inkscape:transform-center-x="-1.6828228"
+         inkscape:transform-center-y="2.09e-05"
+         d="m 165.67113,93.636063 -0.89773,0.518184 c 0.13953,0.298184 0.13404,0.666643 -0.0482,0.982267 -0.1934,0.33498 -0.53842,0.527991 -0.88759,0.536781 v 1.035523 c 0.0804,-0.0031 0.15996,-0.01 0.23923,-0.02282 l 0.43365,0.57313 c 0.0412,0.05071 0.11323,0.06513 0.17414,0.02621 l 0.94507,-0.572285 c 0.0609,-0.03895 0.0852,-0.109055 0.06,-0.170756 l -0.25191,-0.677953 c 0.0534,-0.07019 0.10319,-0.14572 0.15132,-0.229083 0.0467,-0.08083 0.0883,-0.164125 0.12003,-0.246835 l 0.71853,-0.1175 c 0.0636,-0.01042 0.11473,-0.07202 0.1175,-0.137788 l 0.0228,-1.104839 c 0.003,-0.07219 -0.046,-0.124125 -0.10904,-0.136943 l -0.7143,-0.08876 c -0.0222,-0.05681 -0.0472,-0.112354 -0.0735,-0.166529 z" />
+      <path
+         id="path143"
+         style="fill:#99bfff;fill-opacity:1;stroke-width:0.924227;stroke-linecap:round;stroke-linejoin:round"
+         inkscape:transform-center-x="-0.84139295"
+         inkscape:transform-center-y="1.4578557"
+         d="m 164.73113,91.929353 c -0.0386,0.0016 -0.0761,0.02051 -0.10397,0.05495 l -0.45732,0.591727 c -0.17667,-0.02116 -0.35418,-0.01201 -0.5258,0.01353 l -0.43365,-0.573975 c -0.0412,-0.0507 -0.11323,-0.06514 -0.17413,-0.0262 l -0.94254,0.573975 c -0.0594,0.03641 -0.0876,0.107668 -0.06,0.170756 l 0.25698,0.680486 c -0.0558,0.06883 -0.11371,0.146546 -0.15892,0.224856 -0.01,0.01717 -0.0191,0.03546 -0.0287,0.05326 l 0.86476,0.499587 c 0.009,-0.01804 0.0177,-0.03638 0.0279,-0.0541 0.28877,-0.500172 0.91429,-0.68447 1.38971,-0.409983 0.17542,0.101277 0.30642,0.251694 0.388,0.426044 l 0.89774,-0.518184 c -0.0504,-0.103467 -0.10835,-0.202387 -0.17836,-0.295864 l 0.28403,-0.691475 c 0.0254,-0.06617 0.003,-0.136641 -0.055,-0.16991 l -0.92225,-0.532555 c -0.0216,-0.01248 -0.0453,-0.01785 -0.0685,-0.01691 z" />
+    </g>
+  </g>
+</svg>

--- a/qubes_menu/application_page.py
+++ b/qubes_menu/application_page.py
@@ -261,6 +261,7 @@ class AppPage(MenuPage):
         :param desktop_file_manager: Desktop File Manager object
         """
         self.selected_vm_entry: Optional[VMRow] = None
+        self.sort_running = False # Sort running VMs to top
 
         self.vm_list: Gtk.ListBox = builder.get_object('vm_list')
         self.app_list: Gtk.ListBox = builder.get_object('app_list')
@@ -285,7 +286,7 @@ class AppPage(MenuPage):
         self.app_list.invalidate_sort()
 
         vm_manager.register_new_vm_callback(self._vm_callback)
-        self.vm_list.set_sort_func(lambda x, y: x.sort_order > y.sort_order)
+        self.vm_list.set_sort_func(self._sort_vms)
         self.vm_list.set_filter_func(self.toggle_buttons.filter_function)
 
         self.vm_list.connect('row-selected', self._selection_changed)
@@ -319,6 +320,18 @@ class AppPage(MenuPage):
         self.app_list.set_filter_func(None)
         self.app_list.invalidate_filter()
         self.app_list.set_filter_func(self._is_app_fitting)
+
+    def _sort_vms(self, vmentry: VMRow, other_entry: VMRow):
+        if self.sort_running:
+            if vmentry.vm_entry.power_state != other_entry.vm_entry.power_state:
+                if vmentry.vm_entry.power_state == "Running":
+                    return -1
+                return 1
+        return vmentry.sort_order > other_entry.sort_order
+
+    def set_sorting_order(self, sort_running: bool = False):
+        self.sort_running = sort_running
+        self.vm_list.invalidate_sort()
 
     def setup_keynav(self):
         """Do all the required faffing about to convince Gtk to have

--- a/qubes_menu/application_page.py
+++ b/qubes_menu/application_page.py
@@ -263,6 +263,8 @@ class AppPage(MenuPage):
         self.selected_vm_entry: Optional[VMRow] = None
         self.sort_running = False # Sort running VMs to top
 
+        self.page_widget: Gtk.Box = builder.get_object("app_page")
+
         self.vm_list: Gtk.ListBox = builder.get_object('vm_list')
         self.app_list: Gtk.ListBox = builder.get_object('app_list')
         self.settings_list: Gtk.ListBox = builder.get_object('settings_list')

--- a/qubes_menu/appmenu.py
+++ b/qubes_menu/appmenu.py
@@ -9,7 +9,7 @@ import os
 import subprocess
 import sys
 from typing import Optional, Dict
-import pkg_resources
+import importlib.resources
 import logging
 
 import qubesadmin
@@ -282,8 +282,12 @@ class AppMenu(Gtk.Application):
 
         self.fav_app_list = self.builder.get_object('fav_app_list')
         self.sys_tools_list = self.builder.get_object('sys_tools_list')
-        self.builder.add_from_file(pkg_resources.resource_filename(
-            __name__, 'qubes-menu.glade'))
+
+        glade_path = (importlib.resources.files('qubes_menu') /
+                      'qubes-menu.glade')
+        with importlib.resources.as_file(glade_path) as path:
+            self.builder.add_from_file(str(path))
+
         self.main_window = self.builder.get_object('main_window')
         self.main_notebook = self.builder.get_object('main_notebook')
 
@@ -330,11 +334,16 @@ class AppMenu(Gtk.Application):
 
     def load_style(self, *_args):
         """Load appropriate CSS stylesheet and associated properties."""
-        load_theme(self.main_window,
-                   light_theme_path=pkg_resources.resource_filename(
-                       __name__, 'qubes-menu-light.css'),
-                   dark_theme_path=pkg_resources.resource_filename(
-                       __name__, 'qubes-menu-dark.css'))
+        light_ref = (importlib.resources.files('qubes_menu') /
+                     'qubes-menu-light.css')
+        dark_ref = (importlib.resources.files('qubes_menu') /
+                    'qubes-menu-dark.css')
+
+        with importlib.resources.as_file(light_ref) as light_path, \
+                importlib.resources.as_file(dark_ref) as dark_path:
+            load_theme(self.main_window,
+                       light_theme_path=str(light_path),
+                       dark_theme_path=str(dark_path))
 
         label = Gtk.Label()
         style_context: Gtk.StyleContext = label.get_style_context()

--- a/qubes_menu/appmenu.py
+++ b/qubes_menu/appmenu.py
@@ -8,7 +8,7 @@ import asyncio
 import os
 import subprocess
 import sys
-from typing import Optional, Dict
+from typing import Optional, Dict, Any
 import importlib.resources
 import logging
 
@@ -152,15 +152,19 @@ class AppMenu(Gtk.Application):
         options = command_line.get_options_dict()
         # convert GVariantDict -> GVariant -> dict
         options = options.end().unpack()
+        self.parse_options(options)
+        self.activate()
+        return 0
 
+    def parse_options(self, options: Dict[str, Any]):
+        """Parse command-line options."""
         if "keep-visible" in options:
             self.keep_visible = True
         if "page" in options:
-            self.initial_page = self.handles.keys()[options['page']]
+            self.initial_page = [k for k, v in PAGE_NUMS.items()
+                                 if int(v) == int(options["page"])][0]
         if "background" in options:
             self.start_in_background = True
-        self.activate()
-        return 0
 
     @staticmethod
     def _do_power_button(_widget):

--- a/qubes_menu/constants.py
+++ b/qubes_menu/constants.py
@@ -33,6 +33,9 @@ STATE_DICTIONARY = {
     'domain-shutdown-failed': 'Running'
 }
 
+INITIAL_PAGE_FEATURE = 'menu-initial-page'
+SORT_RUNNING_FEATURE = 'menu-sort-running'
+
 FAVORITES_FEATURE = 'menu-favorites'
 DISPOSABLE_PREFIX = '@disp:'
 

--- a/qubes_menu/favorites_page.py
+++ b/qubes_menu/favorites_page.py
@@ -49,6 +49,8 @@ class FavoritesPage(MenuPage):
         self.dispatcher = dispatcher
         self.vm_manager = vm_manager
 
+        self.page_widget: Gtk.Box = builder.get_object("favorites_page")
+
         self.app_list: Gtk.ListBox = builder.get_object('fav_app_list')
         self.app_list.connect('row-activated', self._app_clicked)
 

--- a/qubes_menu/page_handler.py
+++ b/qubes_menu/page_handler.py
@@ -27,3 +27,6 @@ class MenuPage(abc.ABC):
     def initialize_page(self):
         """Perform all initial / post-switch configuration for the page. This
         will be called on start and whenever menu switches to the given page."""
+
+    def set_sorting_order(self, sort_running: bool = False):
+        """Set special sorting order options."""

--- a/qubes_menu/page_handler.py
+++ b/qubes_menu/page_handler.py
@@ -20,9 +20,15 @@
 """Abstract Menu page"""
 import abc
 
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
+
 
 class MenuPage(abc.ABC):
     """Abstract Menu Page."""
+    page_widget: Gtk.Widget
+
     @abc.abstractmethod
     def initialize_page(self):
         """Perform all initial / post-switch configuration for the page. This

--- a/qubes_menu/search_page.py
+++ b/qubes_menu/search_page.py
@@ -99,6 +99,8 @@ class SearchPage(MenuPage):
         self.vm_manager = vm_manager
         self.desktop_file_manager = desktop_file_manager
 
+        self.page_widget: Gtk.Grid = builder.get_object("search_page")
+
         self.sort_running = False  # sort running vms to top
 
         self.vm_list: Gtk.ListBox = builder.get_object('search_vm_list')

--- a/qubes_menu/settings_page.py
+++ b/qubes_menu/settings_page.py
@@ -58,6 +58,8 @@ class SettingsPage(MenuPage):
         self.desktop_file_manager = desktop_file_manager
         self.dispatcher = dispatcher
 
+        self.page_widget: Gtk.Box = builder.get_object("settings_page")
+
         self.app_list: Gtk.ListBox = builder.get_object('sys_tools_list')
         self.app_list.connect('row-activated', self._app_clicked)
         self.app_list.set_sort_func(

--- a/qubes_menu/tests/conftest.py
+++ b/qubes_menu/tests/conftest.py
@@ -19,7 +19,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 import pytest
-import pkg_resources
+import importlib.resources
 from qubesadmin.tests.mock_app import MockQubesComplete
 
 
@@ -37,8 +37,12 @@ def test_qapp():
 def test_builder():
     """Gtk builder with correct menu glade file"""
     builder = Gtk.Builder()
-    builder.add_from_file(pkg_resources.resource_filename(
-        'qubes_menu', 'qubes-menu.glade'))
+
+    glade_path = (importlib.resources.files('qubes_menu') /
+                  'qubes-menu.glade')
+    with importlib.resources.as_file(glade_path) as path:
+        builder.add_from_file(str(path))
+
     return builder
 
 

--- a/qubes_menu/tests/test_appmenu.py
+++ b/qubes_menu/tests/test_appmenu.py
@@ -59,3 +59,30 @@ def test_app_menu_conffeatures_default():
     # check that default configuration is correct
     assert app_menu.initial_page == "app_page"
     assert not app_menu.sort_running
+
+
+def test_appmenu_options():
+    qapp = MockQubesComplete()
+
+    qapp._qubes['test-vm2'] = MockQube(name="test-vm2", qapp=qapp,
+                                       features={'menu-favorites': ''})
+    qapp._qubes['dom0'].features['menu-initial-page'] = 'app_page'
+    qapp._qubes['dom0'].features['menu-sort-running'] = '1'
+    qapp.update_vm_calls()
+
+    dispatcher = MockDispatcher(qapp)
+    app_menu = AppMenu(qapp, dispatcher)
+
+    app_menu.perform_setup()
+
+    assert app_menu.initial_page == "app_page"
+    assert not app_menu.keep_visible
+    options = {
+        "keep-visible": True,
+        "page": "2"
+    }
+
+    app_menu.parse_options(options)
+
+    assert app_menu.initial_page == "favorites_page"
+    assert app_menu.keep_visible

--- a/qubes_menu/tests/test_appmenu.py
+++ b/qubes_menu/tests/test_appmenu.py
@@ -26,7 +26,7 @@ def test_app_menu_conffeatures():
 
     qapp._qubes['test-vm2'] = MockQube(name="test-vm2", qapp=qapp,
                                        features={'menu-favorites': ''})
-    qapp._qubes['dom0'].features['menu-initial-page'] = '2'
+    qapp._qubes['dom0'].features['menu-initial-page'] = 'favorites_page'
     qapp._qubes['dom0'].features['menu-sort-running'] = '1'
     qapp.update_vm_calls()
 
@@ -36,7 +36,7 @@ def test_app_menu_conffeatures():
     app_menu.perform_setup()
 
     # check that initial page is correct
-    assert app_menu.initial_page == 2
+    assert app_menu.initial_page == "favorites_page"
     assert app_menu.sort_running
 
 
@@ -57,5 +57,5 @@ def test_app_menu_conffeatures_default():
     app_menu.perform_setup()
 
     # check that default configuration is correct
-    assert app_menu.initial_page == 1
+    assert app_menu.initial_page == "app_page"
     assert not app_menu.sort_running

--- a/qubes_menu/tests/test_appmenu.py
+++ b/qubes_menu/tests/test_appmenu.py
@@ -1,0 +1,61 @@
+# -*- encoding: utf8 -*-
+#
+# The Qubes OS Project, http://www.qubes-os.org
+#
+# Copyright (C) 2023 Marta Marczykowska-Górecka
+#                               <marmarta@invisiblethingslab.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+from ..appmenu import AppMenu
+from qubesadmin.tests.mock_app import MockQubesComplete, MockDispatcher, MockQube
+
+
+def test_app_menu_conffeatures():
+    qapp = MockQubesComplete()
+
+    qapp._qubes['test-vm2'] = MockQube(name="test-vm2", qapp=qapp,
+                                       features={'menu-favorites': ''})
+    qapp._qubes['dom0'].features['menu-initial-page'] = '2'
+    qapp._qubes['dom0'].features['menu-sort-running'] = '1'
+    qapp.update_vm_calls()
+
+    dispatcher = MockDispatcher(qapp)
+    app_menu = AppMenu(qapp, dispatcher)
+
+    app_menu.perform_setup()
+
+    # check that initial page is correct
+    assert app_menu.initial_page == 2
+    assert app_menu.sort_running
+
+
+def test_app_menu_conffeatures_default():
+    qapp = MockQubesComplete()
+
+    # make sure the features exist, but should not be shown
+    qapp._qubes['test-vm2'] = MockQube(
+        name="test-vm2", qapp=qapp,
+        features={'menu-favorites': '',
+                  'menu-initial-page': 'fake',
+                  'menu-sort-running': 'fake'})
+    qapp.update_vm_calls()
+
+    dispatcher = MockDispatcher(qapp)
+    app_menu = AppMenu(qapp, dispatcher)
+
+    app_menu.perform_setup()
+
+    # check that default configuration is correct
+    assert app_menu.initial_page == 1
+    assert not app_menu.sort_running

--- a/qubes_menu_settings/__init__.py
+++ b/qubes_menu_settings/__init__.py
@@ -1,0 +1,19 @@
+# -*- encoding: utf8 -*-
+#
+# The Qubes OS Project, http://www.qubes-os.org
+#
+# Copyright (C) 2024 Marta Marczykowska-Górecka
+#                               <marmarta@invisiblethingslab.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.

--- a/qubes_menu_settings/menu_settings.css
+++ b/qubes_menu_settings/menu_settings.css
@@ -1,0 +1,11 @@
+.button_save {
+    background: #4488df;
+    color: white;
+}
+
+.flat_button {
+    border-color: #979797;
+    font-weight: 500;
+    margin: 5px;
+    border-radius: 0px;
+}

--- a/qubes_menu_settings/menu_settings.glade
+++ b/qubes_menu_settings/menu_settings.glade
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.40.0 -->
+<interface>
+  <requires lib="gtk+" version="3.24"/>
+  <object class="GtkWindow" id="main_window">
+    <property name="can-focus">False</property>
+    <property name="title" translatable="yes">Qubes App Menu Settings</property>
+    <property name="window-position">center</property>
+    <property name="icon-name">appmenu-settings-program-icon</property>
+    <property name="gravity">center</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="margin-start">10</property>
+        <property name="margin-end">10</property>
+        <property name="margin-top">10</property>
+        <property name="margin-bottom">10</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">20</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">The settings below apply to default Qubes App Menu.</property>
+            <property name="xalign">0</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="spacing">3</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Starting menu page: </property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkImage">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes">This page will be shown when you open the menu.</property>
+                <property name="xalign">0.5</property>
+                <property name="yalign">0.6000000238418579</property>
+                <property name="pixel-size">20</property>
+                <property name="icon-name">qubes-question</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="padding">3</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkComboBox" id="starting_page_combo">
+                <property name="name">starting_page_combo</property>
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="margin-start">10</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <child>
+              <object class="GtkCheckButton" id="sort_running_to_top_check">
+                <property name="label" translatable="yes">Show running qubes at the top</property>
+                <property name="name">sort_running_to_top_check</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
+                <property name="draw-indicator">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkImage">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes">In the qube list in search and in the app page, the running qubes will be sorted to top.</property>
+                <property name="xalign">0.5</property>
+                <property name="yalign">0.6000000238418579</property>
+                <property name="pixel-size">20</property>
+                <property name="icon-name">qubes-question</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="padding">3</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButtonBox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="margin-top">20</property>
+            <property name="spacing">20</property>
+            <property name="layout-style">start</property>
+            <child>
+              <object class="GtkButton" id="button_cancel">
+                <property name="label" translatable="yes">Cancel</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <style>
+                  <class name="flat_button"/>
+                  <class name="flat"/>
+                </style>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button_apply">
+                <property name="label" translatable="yes">Apply</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <style>
+                  <class name="flat_button"/>
+                  <class name="flat"/>
+                </style>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button_confirm">
+                <property name="label" translatable="yes">Confirm</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <style>
+                  <class name="flat_button"/>
+                  <class name="button_save"/>
+                  <class name="flat"/>
+                </style>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/qubes_menu_settings/menu_settings.glade~
+++ b/qubes_menu_settings/menu_settings.glade~
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.40.0 -->
+<interface>
+  <requires lib="gtk+" version="3.24"/>
+  <object class="GtkWindow" id="main_window">
+    <property name="can-focus">False</property>
+    <property name="title" translatable="yes">Qubes App Menu Settings</property>
+    <property name="window-position">center</property>
+    <property name="icon-name">qappmenu-settings</property>
+    <property name="gravity">center</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="margin-start">10</property>
+        <property name="margin-end">10</property>
+        <property name="margin-top">10</property>
+        <property name="margin-bottom">10</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">20</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">The settings below apply to default Qubes App Menu.</property>
+            <property name="xalign">0</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="spacing">3</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Starting menu page: </property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkImage">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes">This page will be shown when you open the menu.</property>
+                <property name="xalign">0.5</property>
+                <property name="yalign">0.6000000238418579</property>
+                <property name="pixel-size">20</property>
+                <property name="icon-name">qubes-question</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="padding">3</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkComboBox" id="starting_page_combo">
+                <property name="name">starting_page_combo</property>
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="margin-start">10</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <child>
+              <object class="GtkCheckButton" id="sort_running_to_top_check">
+                <property name="label" translatable="yes">Show running qubes at the top</property>
+                <property name="name">sort_running_to_top_check</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
+                <property name="draw-indicator">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkImage">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes">In the qube list in search and in the app page, the running qubes will be sorted to top.</property>
+                <property name="xalign">0.5</property>
+                <property name="yalign">0.6000000238418579</property>
+                <property name="pixel-size">20</property>
+                <property name="icon-name">qubes-question</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="padding">3</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButtonBox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="margin-top">20</property>
+            <property name="spacing">20</property>
+            <property name="layout-style">start</property>
+            <child>
+              <object class="GtkButton" id="button_cancel">
+                <property name="label" translatable="yes">Cancel</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <style>
+                  <class name="flat_button"/>
+                  <class name="flat"/>
+                </style>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button_apply">
+                <property name="label" translatable="yes">Apply</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <style>
+                  <class name="flat_button"/>
+                  <class name="flat"/>
+                </style>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button_confirm">
+                <property name="label" translatable="yes">Confirm</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <style>
+                  <class name="flat_button"/>
+                  <class name="button_save"/>
+                  <class name="flat"/>
+                </style>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/qubes_menu_settings/menu_settings.py
+++ b/qubes_menu_settings/menu_settings.py
@@ -1,0 +1,162 @@
+# -*- encoding: utf8 -*-
+#
+# The Qubes OS Project, http://www.qubes-os.org
+#
+# Copyright (C) 2024 Marta Marczykowska-Górecka
+#                               <marmarta@invisiblethingslab.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+import sys
+
+import gi
+import pkg_resources
+
+import qubesadmin
+
+from qubes_config.widgets.gtk_widgets import ImageListModeler
+
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk, Gio, Gdk
+
+from qubes_menu.constants import INITIAL_PAGE_FEATURE, SORT_RUNNING_FEATURE
+
+
+MENU_PAGES = ["Search", "Applications", "Favorites"]
+
+MENU_PAGES_DICT = {
+    "Search": {"icon": "qappmenu-search", "object": 0},
+    "Applications": {"icon": "qappmenu-qube", "object": 1},
+    "Favorites": {"icon": "qappmenu-favorites", "object": 2}}
+
+
+class AppMenuSettings(Gtk.Application):
+    """
+    Qubes Menu Settings app.
+    """
+    def __init__(self, qapp: qubesadmin.Qubes):
+        """
+        :param qapp: qubesadmin.Qubes object
+        """
+        super().__init__(application_id='org.qubesos.appmenusettings')
+        self.qapp = qapp
+        self.vm = self.qapp.domains[self.qapp.local_name]
+
+    def do_activate(self, *args, **kwargs):
+        """
+        Method called whenever this program is run; it executes actual setup
+        only at true first start, in other cases just presenting the main window
+        to user.
+        """
+        self.perform_setup()
+        assert self.main_window
+        self.main_window.show()
+        self.hold()
+
+    def perform_setup(self):
+        # pylint: disable=attribute-defined-outside-init
+        """
+        The function that performs actual widget realization and setup.
+        """
+        self.builder = Gtk.Builder()
+        self.builder.add_from_file(pkg_resources.resource_filename(
+            'qubes_menu_settings', 'menu_settings.glade'))
+
+        self.main_window : Gtk.ApplicationWindow = \
+            self.builder.get_object('main_window')
+
+        self.confirm_button: Gtk.Button = \
+            self.builder.get_object('button_confirm')
+        self.apply_button: Gtk.Button = self.builder.get_object('button_apply')
+        self.cancel_button: Gtk.Button = \
+            self.builder.get_object('button_cancel')
+
+        self.starting_page_combo: Gtk.ComboBox = \
+            self.builder.get_object("starting_page_combo")
+
+        self.sort_running_check: Gtk.CheckButton = \
+            self.builder.get_object("sort_running_to_top_check")
+
+        screen = Gdk.Screen.get_default()
+        provider = Gtk.CssProvider()
+        provider.load_from_path(pkg_resources.resource_filename(
+                       'qubes_menu_settings', 'menu_settings.css'))
+        Gtk.StyleContext.add_provider_for_screen(
+            screen, provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+
+        self.confirm_button.connect("clicked", self._save_exit)
+        self.apply_button.connect("clicked", self._save)
+        self.cancel_button.connect("clicked", self._quit)
+
+        self.initial_page_model = ImageListModeler(
+            self.starting_page_combo,
+            {
+                "Search": {"icon": "qappmenu-search", "object": 0},
+                "Applications": {"icon": "qappmenu-qube", "object": 1},
+                "Favorites": {"icon": "qappmenu-favorites", "object": 2},
+            })
+
+        self.load_state()
+
+    def load_state(self):
+        try:
+            initial_page = int(self.vm.features.get(INITIAL_PAGE_FEATURE, 1))
+        except ValueError:
+            initial_page = 1
+        if initial_page < 0 or initial_page > 2:
+            initial_page = 1
+
+        self.initial_page_model.select_name(MENU_PAGES[initial_page])
+        self.initial_page_model.update_initial()
+
+        # this can sometimes be None, thus, the "or False)
+        sort_running = \
+            bool(self.vm.features.get(SORT_RUNNING_FEATURE, False) or False)
+        self.sort_running_check.set_active(sort_running)
+
+    def _quit(self, *_args):
+        self.quit()
+
+    def _save(self, *_args):
+        """Save changes."""
+        old_sort_running = self.vm.features.get(SORT_RUNNING_FEATURE, None)
+
+        if self.sort_running_check.get_active():
+            if not old_sort_running:
+                self.vm.features[SORT_RUNNING_FEATURE] = "1"
+        else:
+            if old_sort_running:
+                del self.vm.features[SORT_RUNNING_FEATURE]
+
+        old_initial_page = int(self.vm.features.get(INITIAL_PAGE_FEATURE, 1))
+
+        if self.initial_page_model.get_selected() != old_initial_page:
+            self.vm.features[INITIAL_PAGE_FEATURE] = \
+                self.initial_page_model.get_selected()
+
+    def _save_exit(self, *_args):
+        self._save()
+        self._quit()
+
+
+def main():
+    """
+    Start the app
+    """
+    qapp = qubesadmin.Qubes()
+    app = AppMenuSettings(qapp)
+    app.run()
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/qubes_menu_settings/menu_settings.py
+++ b/qubes_menu_settings/menu_settings.py
@@ -35,12 +35,16 @@ from gi.repository import Gtk, Gdk
 from qubes_menu.constants import INITIAL_PAGE_FEATURE, SORT_RUNNING_FEATURE
 
 
-MENU_PAGES = ["Search", "Applications", "Favorites"]
+MENU_PAGES = {
+    "search_page": "Search",
+    "app_page": "Applications",
+    "favorites_page": "Favorites"
+}
 
 MENU_PAGES_DICT = {
-    "Search": {"icon": "qappmenu-search", "object": 0},
-    "Applications": {"icon": "qappmenu-qube", "object": 1},
-    "Favorites": {"icon": "qappmenu-favorites", "object": 2}}
+    "Search": {"icon": "qappmenu-search", "object": "search_page"},
+    "Applications": {"icon": "qappmenu-qube", "object": "app_page"},
+    "Favorites": {"icon": "qappmenu-favorites", "object": "favorites_page"}}
 
 
 class AppMenuSettings(Gtk.Application):
@@ -109,12 +113,7 @@ class AppMenuSettings(Gtk.Application):
         self.cancel_button.connect("clicked", self._quit)
 
         self.initial_page_model = ImageListModeler(
-            self.starting_page_combo,
-            {
-                "Search": {"icon": "qappmenu-search", "object": 0},
-                "Applications": {"icon": "qappmenu-qube", "object": 1},
-                "Favorites": {"icon": "qappmenu-favorites", "object": 2},
-            })
+            self.starting_page_combo, MENU_PAGES_DICT)
 
         self.load_state()
 
@@ -122,12 +121,9 @@ class AppMenuSettings(Gtk.Application):
         """
         Load current settings from local vm's features.
         """
-        try:
-            initial_page = int(self.vm.features.get(INITIAL_PAGE_FEATURE, 1))
-        except ValueError:
-            initial_page = 1
-        if initial_page < 0 or initial_page > 2:
-            initial_page = 1
+        initial_page = self.vm.features.get(INITIAL_PAGE_FEATURE, "app_page")
+        if initial_page not in MENU_PAGES:
+            initial_page = "app_page"
 
         self.initial_page_model.select_name(MENU_PAGES[initial_page])
         self.initial_page_model.update_initial()
@@ -151,7 +147,8 @@ class AppMenuSettings(Gtk.Application):
             if old_sort_running:
                 del self.vm.features[SORT_RUNNING_FEATURE]
 
-        old_initial_page = int(self.vm.features.get(INITIAL_PAGE_FEATURE, 1))
+        old_initial_page = self.vm.features.get(INITIAL_PAGE_FEATURE,
+                                                "app_page")
 
         if self.initial_page_model.get_selected() != old_initial_page:
             self.vm.features[INITIAL_PAGE_FEATURE] = \

--- a/qubes_menu_settings/menu_settings.py
+++ b/qubes_menu_settings/menu_settings.py
@@ -17,6 +17,9 @@
 #
 # You should have received a copy of the GNU Lesser General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
+"""
+Settings for Qubes App Menu.
+"""
 import sys
 
 import gi
@@ -27,7 +30,7 @@ import qubesadmin
 from qubes_config.widgets.gtk_widgets import ImageListModeler
 
 gi.require_version('Gtk', '3.0')
-from gi.repository import Gtk, Gio, Gdk
+from gi.repository import Gtk, Gdk
 
 from qubes_menu.constants import INITIAL_PAGE_FEATURE, SORT_RUNNING_FEATURE
 
@@ -109,6 +112,9 @@ class AppMenuSettings(Gtk.Application):
         self.load_state()
 
     def load_state(self):
+        """
+        Load current settings from local vm's features.
+        """
         try:
             initial_page = int(self.vm.features.get(INITIAL_PAGE_FEATURE, 1))
         except ValueError:
@@ -121,7 +127,7 @@ class AppMenuSettings(Gtk.Application):
 
         # this can sometimes be None, thus, the "or False)
         sort_running = \
-            bool(self.vm.features.get(SORT_RUNNING_FEATURE, False) or False)
+            bool(self.vm.features.get(SORT_RUNNING_FEATURE, False))
         self.sort_running_check.set_active(sort_running)
 
     def _quit(self, *_args):

--- a/qubes_menu_settings/menu_settings.py
+++ b/qubes_menu_settings/menu_settings.py
@@ -23,7 +23,7 @@ Settings for Qubes App Menu.
 import sys
 
 import gi
-import pkg_resources
+import importlib.resources
 
 import qubesadmin
 
@@ -72,8 +72,11 @@ class AppMenuSettings(Gtk.Application):
         The function that performs actual widget realization and setup.
         """
         self.builder = Gtk.Builder()
-        self.builder.add_from_file(pkg_resources.resource_filename(
-            'qubes_menu_settings', 'menu_settings.glade'))
+
+        glade_path = (importlib.resources.files('qubes_menu_settings') /
+                      'menu_settings.glade')
+        with importlib.resources.as_file(glade_path) as path:
+            self.builder.add_from_file(str(path))
 
         self.main_window : Gtk.ApplicationWindow = \
             self.builder.get_object('main_window')
@@ -92,8 +95,12 @@ class AppMenuSettings(Gtk.Application):
 
         screen = Gdk.Screen.get_default()
         provider = Gtk.CssProvider()
-        provider.load_from_path(pkg_resources.resource_filename(
-                       'qubes_menu_settings', 'menu_settings.css'))
+
+        css_path = (importlib.resources.files('qubes_menu_settings') /
+                      'menu_settings.css')
+        with importlib.resources.as_file(css_path) as path:
+            provider.load_from_path(str(path))
+
         Gtk.StyleContext.add_provider_for_screen(
             screen, provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
 

--- a/qubes_menu_settings/test_menu_settings.py
+++ b/qubes_menu_settings/test_menu_settings.py
@@ -24,7 +24,7 @@ from qubesadmin.tests.mock_app import MockQubesComplete
 
 def test_menu_settings_load():
     qapp = MockQubesComplete()
-    qapp._qubes['dom0'].features['menu-initial-page'] = '2'
+    qapp._qubes['dom0'].features['menu-initial-page'] = 'favorites_page'
     qapp._qubes['dom0'].features['menu-sort-running'] = '1'
     qapp._qubes['dom0'].features['menu-favorites'] = ''
 
@@ -34,13 +34,13 @@ def test_menu_settings_load():
 
     app.perform_setup()
 
-    assert app.initial_page_model.get_selected() == 2
+    assert app.initial_page_model.get_selected() == "favorites_page"
     assert app.sort_running_check.get_active()
 
 
 def test_menu_settings_change():
     qapp = MockQubesComplete()
-    qapp._qubes['dom0'].features['menu-initial-page'] = '1'
+    qapp._qubes['dom0'].features['menu-initial-page'] = 'app_page'
     qapp._qubes['dom0'].features['menu-sort-running'] = ''
     qapp._qubes['dom0'].features['menu-favorites'] = ''
 
@@ -50,21 +50,21 @@ def test_menu_settings_change():
 
     app.perform_setup()
 
-    assert app.initial_page_model.get_selected() == 1
+    assert app.initial_page_model.get_selected() == "app_page"
     assert not app.sort_running_check.get_active()
 
     app.starting_page_combo.set_active_id("Search")  # the first option is search
     app.sort_running_check.set_active(True)
 
     qapp.expected_calls[('dom0', 'admin.vm.feature.Set', 'menu-sort-running', b'1')] = b'0\0'
-    qapp.expected_calls[('dom0', 'admin.vm.feature.Set', 'menu-initial-page', b'0')] = b'0\0'
+    qapp.expected_calls[('dom0', 'admin.vm.feature.Set', 'menu-initial-page', b'search_page')] = b'0\0'
 
     app._save()
 
 
 def test_menu_settings_change2():
     qapp = MockQubesComplete()
-    qapp._qubes['dom0'].features['menu-initial-page'] = '1'
+    qapp._qubes['dom0'].features['menu-initial-page'] = 'app_page'
     qapp._qubes['dom0'].features['menu-sort-running'] = ''
     qapp._qubes['dom0'].features['menu-favorites'] = ''
 
@@ -74,11 +74,11 @@ def test_menu_settings_change2():
 
     app.perform_setup()
 
-    assert app.initial_page_model.get_selected() == 1
+    assert app.initial_page_model.get_selected() == "app_page"
     assert not app.sort_running_check.get_active()
 
     app.starting_page_combo.set_active_id("Favorites")
 
-    qapp.expected_calls[('dom0', 'admin.vm.feature.Set', 'menu-initial-page', b'2')] = b'0\0'
+    qapp.expected_calls[('dom0', 'admin.vm.feature.Set', 'menu-initial-page', b'favorites_page')] = b'0\0'
 
     app._save()

--- a/qubes_menu_settings/test_menu_settings.py
+++ b/qubes_menu_settings/test_menu_settings.py
@@ -1,0 +1,84 @@
+# pylint: skip-file
+# -*- encoding: utf8 -*-
+#
+# The Qubes OS Project, http://www.qubes-os.org
+#
+# Copyright (C) 2023 Marta Marczykowska-Górecka
+#                               <marmarta@invisiblethingslab.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+from .menu_settings import AppMenuSettings
+from qubesadmin.tests.mock_app import MockQubesComplete
+
+
+def test_menu_settings_load():
+    qapp = MockQubesComplete()
+    qapp._qubes['dom0'].features['menu-initial-page'] = '2'
+    qapp._qubes['dom0'].features['menu-sort-running'] = '1'
+    qapp._qubes['dom0'].features['menu-favorites'] = ''
+
+    qapp.update_vm_calls()
+
+    app = AppMenuSettings(qapp)
+
+    app.perform_setup()
+
+    assert app.initial_page_model.get_selected() == 2
+    assert app.sort_running_check.get_active()
+
+
+def test_menu_settings_change():
+    qapp = MockQubesComplete()
+    qapp._qubes['dom0'].features['menu-initial-page'] = '1'
+    qapp._qubes['dom0'].features['menu-sort-running'] = ''
+    qapp._qubes['dom0'].features['menu-favorites'] = ''
+
+    qapp.update_vm_calls()
+
+    app = AppMenuSettings(qapp)
+
+    app.perform_setup()
+
+    assert app.initial_page_model.get_selected() == 1
+    assert not app.sort_running_check.get_active()
+
+    app.starting_page_combo.set_active_id("Search")  # the first option is search
+    app.sort_running_check.set_active(True)
+
+    qapp.expected_calls[('dom0', 'admin.vm.feature.Set', 'menu-sort-running', b'1')] = b'0\0'
+    qapp.expected_calls[('dom0', 'admin.vm.feature.Set', 'menu-initial-page', b'0')] = b'0\0'
+
+    app._save()
+
+
+def test_menu_settings_change2():
+    qapp = MockQubesComplete()
+    qapp._qubes['dom0'].features['menu-initial-page'] = '1'
+    qapp._qubes['dom0'].features['menu-sort-running'] = ''
+    qapp._qubes['dom0'].features['menu-favorites'] = ''
+
+    qapp.update_vm_calls()
+
+    app = AppMenuSettings(qapp)
+
+    app.perform_setup()
+
+    assert app.initial_page_model.get_selected() == 1
+    assert not app.sort_running_check.get_active()
+
+    app.starting_page_combo.set_active_id("Favorites")
+
+    qapp.expected_calls[('dom0', 'admin.vm.feature.Set', 'menu-initial-page', b'2')] = b'0\0'
+
+    app._save()

--- a/rpm_spec/qubes-desktop-linux-menu.spec.in
+++ b/rpm_spec/qubes-desktop-linux-menu.spec.in
@@ -51,8 +51,8 @@ Requires:  python%{python3_pkgversion}-gbulb
 Requires:  gtk3
 Requires:  python%{python3_pkgversion}-qubesadmin >= 4.1.8
 Requires:  qubes-artwork >= 4.1.5
-
-Provides:   qubes_menu = %{version}-%{release}
+Requires:  qubes-desktop-linux-manager
+Provides:  qubes_menu = %{version}-%{release}
 
 
 %description
@@ -108,7 +108,16 @@ gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
 %{python3_sitelib}/qubes_menu/qubes-menu-light.css
 %{python3_sitelib}/qubes_menu/qubes-menu-base.css
 
+%dir %{python3_sitelib}/qubes_menu_settings
+%dir %{python3_sitelib}/qubes_menu_settings/__pycache__
+%{python3_sitelib}/qubes_menu_settings/__pycache__/*
+%{python3_sitelib}/qubes_menu_settings/__init__.py
+%{python3_sitelib}/qubes_menu_settings/menu_settings.py
+%{python3_sitelib}/qubes_menu_settings/menu_settings.glade
+%{python3_sitelib}/qubes_menu_settings/menu_settings.css
+
 %{_bindir}/qubes-app-menu
+%{_bindir}/qubes-appmenu-settings
 /usr/share/icons/hicolor/scalable/apps/qappmenu-dispvm-child.svg
 /usr/share/icons/hicolor/scalable/apps/qappmenu-favorites.svg
 /usr/share/icons/hicolor/scalable/apps/qappmenu-favorites-blue.svg
@@ -120,9 +129,11 @@ gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
 /usr/share/icons/hicolor/scalable/apps/qappmenu-qube.svg
 /usr/share/icons/hicolor/scalable/apps/qappmenu-search.svg
 /usr/share/icons/hicolor/scalable/apps/qappmenu-settings.svg
+/usr/share/icons/hicolor/scalable/apps/appmenu-settings-program-icon.svg
 
 /etc/xdg/autostart/qubes-app-menu.desktop
 /usr/share/applications/open-qubes-app-menu.desktop
+/usr/share/applications/qubes-appmenu-settings.desktop
 
 /lib/systemd/user/qubes-app-menu.service
 /usr/share/dbus-1/services/dbus-qubes-app-menu.service

--- a/rpm_spec/qubes-desktop-linux-menu.spec.in
+++ b/rpm_spec/qubes-desktop-linux-menu.spec.in
@@ -113,6 +113,7 @@ gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
 %{python3_sitelib}/qubes_menu_settings/__pycache__/*
 %{python3_sitelib}/qubes_menu_settings/__init__.py
 %{python3_sitelib}/qubes_menu_settings/menu_settings.py
+%{python3_sitelib}/qubes_menu_settings/test_menu_settings.py
 %{python3_sitelib}/qubes_menu_settings/menu_settings.glade
 %{python3_sitelib}/qubes_menu_settings/menu_settings.css
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-python3 -m coverage run -m pytest -vv qubes_menu/tests
+python3 -m coverage run -m pytest -vv qubes_menu/tests qubes_menu_settings
 

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,11 @@ setuptools.setup(name='qubes_menu',
                  description='Qubes App Menu',
                  license='GPL2+',
                  url='https://www.qubes-os.org/',
-                 packages=["qubes_menu"],
+                 packages=["qubes_menu", "qubes_menu_settings"],
                  entry_points={
                      'gui_scripts': [
                          'qubes-app-menu = qubes_menu.appmenu:main',
+                         'qubes-appmenu-settings = qubes_menu_settings.menu_settings:main',
                      ]
                  },
                  package_data={
@@ -20,5 +21,8 @@ setuptools.setup(name='qubes_menu',
                                     "qubes-menu-dark.css",
                                     "qubes-menu-light.css",
                                     "qubes-menu-base.css",
-                                    ]},
+                                    ],
+                     "qubes_menu_settings": ["menu_settings.glade",
+                                             "menu_settings.css"]
+                 },
 )


### PR DESCRIPTION
Add menu settings and small program to set them for the following:
- sort running qubes to top
- initial menu page to show

Also a small update: replaces deprecated pkg_resources with importlib.

references QubesOS/qubes-issues#8043
fixes QubesOS/qubes-issues#8360