### PR TITLE
Layer shell support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ checks:pylint:
   stage: checks
   before_script:
     - sudo dnf install -y python3-gobject gtk3 xorg-x11-server-Xvfb 
-      python3-pip python3-mypy
+      python3-pip python3-mypy gtk-layer-shell
     - pip3 install --quiet -r ci/requirements.txt
     - git clone https://github.com/QubesOS/qubes-core-admin-client ~/core-admin-client
   script:
@@ -25,7 +25,7 @@ checks:tests:
     - "PATH=$PATH:$HOME/.local/bin"
     - sudo dnf install -y python3-gobject gtk3 python3-pytest python3-pytest-asyncio
       python3-coverage xorg-x11-server-Xvfb python3-inotify sequoia-sqv 
-      python3-pip
+      python3-pip gtk-layer-shell
     - pip3 install --quiet -r ci/requirements.txt
     - git clone https://github.com/QubesOS/qubes-core-admin-client ~/core-admin-client
     - git clone https://github.com/QubesOS/qubes-desktop-linux-manager ~/desktop-linux-manager

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,8 @@ Build-Depends:
  qubes-desktop-linux-manager,
  python3-gi,
  gobject-introspection,
- gir1.2-gtk-3.0
+ gir1.2-gtk-3.0,
+ gir1.2-gtklayershell-0.1,
 Standards-Version: 3.9.5
 Homepage: https://www.qubes-os.org/
 X-Python3-Version: >= 3.5

--- a/rpm_spec/qubes-desktop-linux-menu.spec.in
+++ b/rpm_spec/qubes-desktop-linux-menu.spec.in
@@ -49,6 +49,7 @@ BuildRequires:  gettext
 Requires:  python%{python3_pkgversion}-setuptools
 Requires:  python%{python3_pkgversion}-gbulb
 Requires:  gtk3
+Requires:  gtk-layer-shell
 Requires:  python%{python3_pkgversion}-qubesadmin >= 4.1.8
 Requires:  qubes-artwork >= 4.1.5
 Requires:  qubes-desktop-linux-manager


### PR DESCRIPTION
This is almost completely working under Wayland.  To test, use a compositor that supports Layer Shell, such as KWin.  KWin can be spawned nested inside an X11 window, such as what Qubes OS provides.

Issues:

1. [x] The window is too short: fixed by explicitly setting the menu size every time the window is opened.
2. [x] The configuration options that control where the app menu appears did not work: fixed by explicitly checking for them and anchoring the window to the correct corner
3. [x] Tests code was included in the production script: I moved the test code to my own local branch.
4. [ ] `mouse` mode is interpreted as `bottom-left` (KDE) or `top-left` (otherwise): will be fixed by providing mouse information via IPC.

Fixes https://github.com/QubesOS/qubes-issues/issues/9600