### PR TITLE
Always insert spaces into search bar

### DIFF
--- a/qubes_menu/appmenu.py
+++ b/qubes_menu/appmenu.py
@@ -344,13 +344,12 @@ class AppMenu(Gtk.Application):
         if event.keyval == Gdk.KEY_Escape:
             self.hide_menu()
         if event.keyval == Gdk.KEY_space:
-            current_widget = self.get_active_window().get_focus()
-            if isinstance(current_widget,
-                          Gtk.SearchEntry):
-                p = current_widget.get_position()
-                current_widget.insert_text(" ", p)
-                current_widget.set_position(p + 1)
-                return True
+            search_page = self.handlers.get('search_page')
+            if isinstance(search_page, SearchPage):
+                p = search_page.search_entry.get_position()
+                search_page.search_entry.insert_text(" ", p)
+                search_page.search_entry.set_position(p + 1)
+            return True
         return False
 
     def _focus_out(self, _widget, _event: Gdk.EventFocus):


### PR DESCRIPTION
Fixes https://github.com/QubesOS/qubes-issues/issues/8789. Follow up to #47, cc @marmarta. This combines elements of different versions of that PR. 

Alternative: could let a focused search bar insert the space itself by wrapping all of this in in the previously present
```py
if not isinstance(self.get_active_window().get_focus(), Gtk.SearchEntry):
```

Developed and tested on top of branch `release4.2`.

Tested scenarios from previous PR:
- Pressing space does not interfere with arrow key navigation on any page.
- Spaces can be inserted in the middle of the search text.

Still weird:
- Pressing space when the search bar is not focused never focuses it (unlike letter keys).
- Pressing space when the search page is not visible does not show the search page (unlike letter keys) but does still add a space to the invisible search bar.
-  The `_key_press` and `_key_pressed` methods appear to handle the same events. Combining them would make it easier to address the previous point.