### PR TITLE
debian: include gir1.2-gtklayershell-0.1 in runtime deps too

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -32,6 +32,7 @@ Architecture: any
 Depends:
  python3-qubesadmin,
  python3-xdg,
+ gir1.2-gtklayershell-0.1,
  ${python3:Depends},
  ${misc:Depends}
 Description: Qubes UI Applications


### PR DESCRIPTION
This one isn't automatically detected by debhelper, so include it
explicitly.

QubesOS/qubes-issues#8841