### PR TITLE
Show shutdown/restart/sleep options in logout dialog

### DIFF
--- a/qubes_menu/appmenu.py
+++ b/qubes_menu/appmenu.py
@@ -194,7 +194,7 @@ class AppMenu(Gtk.Application):
                 "/LogoutPrompt",  # object_path
                 "org.kde.LogoutPrompt")  # interface
             proxy.call(
-                'promptLogout',  # method name
+                'promptAll',  # method name
                 None,  # parameters
                 0,  # flags
                 0  # timeout_msec


### PR DESCRIPTION
After upgrade to Qubes 4.3, the power button in KDE menu only showed the logout option. Update the DBus call to show all options.