### PR TITLE
Skip confusing buttons from dom0 and disp template

### DIFF
--- a/qubes_menu/app_widgets.py
+++ b/qubes_menu/app_widgets.py
@@ -45,7 +45,7 @@ from gi.repository import Gtk, Gdk
 
 logger = logging.getLogger("qubes-appmenu")
 
-DISP_TEXT = "new Disposable Qube from "
+DISP_TEXT = "New disposable qube from "
 
 
 class AppEntry(Gtk.ListBoxRow):

--- a/qubes_menu/application_page.py
+++ b/qubes_menu/application_page.py
@@ -342,7 +342,9 @@ class AppPage(MenuPage):
             self.selected_vm_entry = row
             self._set_right_visibility(True)
             self.network_indicator.set_network_state(row.vm_entry.has_network)
-            self.control_list.update_visibility(row.vm_entry.power_state)
+            self.control_list.update_visibility(
+                row.vm_entry, self.toggle_buttons.apps_toggle.get_active()
+            )
             self.control_list.unselect_all()
             self.app_list.ephemeral_vm = bool(self.selected_vm_entry.vm_entry.parent_vm)
         self.app_list.invalidate_filter()

--- a/qubes_menu/search_page.py
+++ b/qubes_menu/search_page.py
@@ -511,7 +511,7 @@ class SearchPage(MenuPage):
         else:
             self.selected_vm_row = row
             self.control_list.show()
-            self.control_list.update_visibility(row.vm_entry.power_state)
+            self.control_list.update_visibility(row.vm_entry, apps_tab=False)
             self.control_list.unselect_all()
         self.app_list.invalidate_filter()
         self.app_list.select_row(None)

--- a/qubes_menu/tests/test_app_page.py
+++ b/qubes_menu/tests/test_app_page.py
@@ -30,43 +30,104 @@ def test_app_page_vm_state(test_desktop_file_path, test_qapp, test_builder):
     dispatcher = MockDispatcher(test_qapp)
     vm_manager = VMManager(test_qapp, dispatcher)
 
-    with mock.patch.object(DesktopFileManager, 'desktop_dirs',
-                           [test_desktop_file_path]):
+    with mock.patch.object(
+        DesktopFileManager, "desktop_dirs", [test_desktop_file_path]
+    ):
         desktop_file_manager = DesktopFileManager(test_qapp)
 
     app_page = AppPage(vm_manager, test_builder, desktop_file_manager)
 
-    # select a turned off vm
-    app_page.vm_list.select_row([row for row in app_page.vm_list.get_children()
-                                 if row.vm_name == 'test-red'][0])
+    # For some reason it defaults to the system tab.
+    app_page.toggle_buttons.apps_toggle.set_active(True)
 
-    assert app_page.control_list.start_item.row_label.get_label() == \
-           "Start qube"
-    assert app_page.control_list.pause_item.row_label.get_label() == \
-           " "
+    # select dom0
+    app_page.vm_list.select_row(
+        [
+            row
+            for row in app_page.vm_list.get_children()
+            if row.vm_name == "dom0"
+        ][0]
+    )
+    assert app_page.control_list.start_item.row_label.get_label() == " "
+    assert app_page.control_list.pause_item.row_label.get_label() == " "
+
+    # select a turned off vm
+    app_page.vm_list.select_row(
+        [
+            row
+            for row in app_page.vm_list.get_children()
+            if row.vm_name == "test-red"
+        ][0]
+    )
+
+    assert (
+        app_page.control_list.start_item.row_label.get_label() == "Start qube"
+    )
+    assert app_page.control_list.pause_item.row_label.get_label() == " "
 
     # select a turned on vm
-    app_page.vm_list.select_row([row for row in app_page.vm_list.get_children()
-                                 if row.vm_name == 'sys-usb'][0])
+    app_page.vm_list.select_row(
+        [
+            row
+            for row in app_page.vm_list.get_children()
+            if row.vm_name == "sys-usb"
+        ][0]
+    )
 
-    assert app_page.control_list.start_item.row_label.get_label() == \
-           "Shutdown qube"
-    assert app_page.control_list.pause_item.row_label.get_label() == \
-           "Pause qube"
+    assert (
+        app_page.control_list.start_item.row_label.get_label()
+        == "Shutdown qube"
+    )
+    assert (
+        app_page.control_list.pause_item.row_label.get_label() == "Pause qube"
+    )
+
+    # select a turned off disposable template
+    app_page.vm_list.select_row(
+        [
+            row
+            for row in app_page.vm_list.get_children()
+            if row.vm_name == "test-alt-dvm"
+        ][0]
+    )
+    assert app_page.control_list.start_item.row_label.get_label() == " "
+    assert app_page.control_list.pause_item.row_label.get_label() == " "
+
+    # select a turned on disposable template
+    app_page.vm_list.select_row(
+        [
+            row
+            for row in app_page.vm_list.get_children()
+            if row.vm_name == "test-alt-dvm-running"
+        ][0]
+    )
+    assert (
+        app_page.control_list.start_item.row_label.get_label()
+        == "Shutdown qube"
+    )
+    assert (
+        app_page.control_list.pause_item.row_label.get_label() == "Pause qube"
+    )
 
 
 def test_dispvm_parent_sorting(test_desktop_file_path, test_qapp, test_builder):
     # check if dispvm child is sorted after the parent
-    test_qapp._qubes['disp1233'] = MockQube(
-        name="disp1233", qapp=test_qapp, klass='DispVM',
-        template_for_dispvms='True', template='default-dvm', auto_cleanup=True)
+    test_qapp._qubes["disp1233"] = MockQube(
+        name="disp1233",
+        qapp=test_qapp,
+        klass="DispVM",
+        template_for_dispvms="True",
+        template="default-dvm",
+        auto_cleanup=True,
+    )
     test_qapp.update_vm_calls()
 
     dispatcher = MockDispatcher(test_qapp)
     vm_manager = VMManager(test_qapp, dispatcher)
 
-    with mock.patch.object(DesktopFileManager, 'desktop_dirs',
-                           [test_desktop_file_path]):
+    with mock.patch.object(
+        DesktopFileManager, "desktop_dirs", [test_desktop_file_path]
+    ):
         desktop_file_manager = DesktopFileManager(test_qapp)
 
     app_page = AppPage(vm_manager, test_builder, desktop_file_manager)
@@ -75,11 +136,11 @@ def test_dispvm_parent_sorting(test_desktop_file_path, test_qapp, test_builder):
 
     for row in app_page.vm_list.get_children():
         if found_dvm:
-            if row.vm_name == 'disp1233' and row.vm_entry.parent_vm:
+            if row.vm_name == "disp1233" and row.vm_entry.parent_vm:
                 break
             found_dvm = False
             continue
-        if row.vm_name == 'default-dvm' and row.vm_entry._is_dispvm_template:
+        if row.vm_entry.is_dispvm_template:
             found_dvm = True
             continue
         found_dvm = False
@@ -92,12 +153,14 @@ def test_settings_app_page(test_desktop_file_path, test_qapp, test_builder):
     dispatcher = MockDispatcher(test_qapp)
     vm_manager = VMManager(test_qapp, dispatcher)
 
-    with mock.patch.object(DesktopFileManager, 'desktop_dirs',
-                           [test_desktop_file_path]):
+    with mock.patch.object(
+        DesktopFileManager, "desktop_dirs", [test_desktop_file_path]
+    ):
         desktop_file_manager = DesktopFileManager(test_qapp)
 
-    settings_page = SettingsPage(test_qapp, test_builder,
-                                 desktop_file_manager, dispatcher)
+    settings_page = SettingsPage(
+        test_qapp, test_builder, desktop_file_manager, dispatcher
+    )
 
     for row in settings_page.app_list.get_children():
         assert not row.app_info.vm


### PR DESCRIPTION
- Dom0: hide shutdown and pause, technically, shutdown can be used by GUIVMs in the future if the action was modified, currently, qubesd logs a failure.
- There is no possibility to differentiate between "APPS" and "TEMPLATES" tabs, this means that disposable template "Start qube" is hidden from both tabs, that is not the intended behavior though but would require a redesign to fix. Current behavior though, allows searching for "default-dvm" and not have the "Start qube" button appear. Therefore, to start the disposable template from the app menu, select an application in the "TEMPLATES" tab.

Fixes: https://github.com/QubesOS/qubes-issues/issues/10288
For: https://github.com/QubesOS/qubes-issues/issues/1512
Requires: https://github.com/QubesOS/qubes-core-admin-client/pull/384